### PR TITLE
Mudanças no skeleton e README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To use **coppedown** from [RStudio](http://www.rstudio.com/products/rstudio/down
 ```
 if (!require("devtools")) install.packages("devtools", repos = "http://cran.rstudio.org")
 devtools::install_github("rstudio/bookdown")
-devtools::install_github("mralbu/coppedown")
+devtools::install_github("COPPE-UFRJ/coppedown")
 ```
 
 3) Use the **New R Markdown** dialog to select **Thesis**, here are the steps, and a screenshot below:

--- a/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
@@ -9,7 +9,7 @@ date_year: '2020'
 keyword: [Primeira palavra-chave, Segunda palavra-chave]
 author:
 - name: Zé
-  surname: Pretim
+  surname: Ninguém
 advisor:
 - title: Prof.
   name: Nome do Primeiro Orientador
@@ -47,11 +47,11 @@ bibliography: bib/thesis.bib
 biblio-style: "coppe-unsrt"
 link-citations: true
 output: 
-   thesisdown::thesis_pdf: default
-#  thesisdown::thesis_gitbook: default
-#  thesisdown::thesis_word: 
+   coppedown::thesis_pdf: default
+#  coppedown::thesis_gitbook: default
+#  coppedown::thesis_word: 
 #    reference_docx: template_docx.docx
-#  thesisdown::thesis_epub: default
+#  coppedown::thesis_epub: default
 
 # If you prefer blank lines between paragraphs, un-silence lines  40-41 (this requires package tikz)
 #header-includes:

--- a/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
@@ -8,8 +8,8 @@ date_month: '09'
 date_year: '2020'
 keyword: [Primeira palavra-chave, Segunda palavra-chave]
 author:
-- name: Zé
-  surname: Ninguém
+- name: Nome do Autor
+  surname: Sobrenome
 advisor:
 - title: Prof.
   name: Nome do Primeiro Orientador

--- a/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
@@ -77,7 +77,7 @@ If you receive a duplicate label error after knitting, make sure to delete the i
 if(!require(devtools))
   install.packages("devtools", repos = "http://cran.rstudio.com")
 if(!require(coppedown))
-  devtools::install_github("mralbu/coppedown")
+  devtools::install_github("COPPE-UFRJ/coppedown")
 library(coppedown)
 ```
 


### PR DESCRIPTION
Primeiramente, muito obrigado pelo ótimo template! Tava criando coragem pra escrever minha dissertação pelo RMarkdown e com certeza isso já facilitou demais!!

A correção relacionada aos `coppedown::` são porque fui dar um knit pela primeira vez do zero e recebi o erro `Error in loadNamespace(name) : there is no package called ‘thesisdown’`.

As mudanças no README são para garantir que o usuário faça o download do repositório da COPPE-UFRJ (pelo que entendi este é o padrão agora) e pra dar um nome do autor relativamente menos informal que o outro, já que o repo agora "pertence" à UFRJ, mas fique à vontade para rejeitar a sugestão caso acredite que não seja necessária.

Rodando do zero também recebi uns warnings sobre as referências utilizadas no template (abaixo), e percebi que a página de referências tá sem o título. Vou tentar tirar um tempo amanhã pra entender o que rolou.

```
pandoc-citeproc: reference angel2000 not found
pandoc-citeproc: reference goochandgooch2001 not found
pandoc-citeproc: reference goochandgooch2001 not found
pandoc-citeproc: reference Molina1994 not found
pandoc-citeproc: reference reedweb2007 not found
pandoc-citeproc: reference noble2002 not found

Output created: _book/thesis.pdf
Warning message:
LaTeX Warning: Reference `bib:begin' on page iii undefined on input line 76.
LaTeX Warning: Reference `bib:end' on page iii undefined on input line 76.
LaTeX Warning: Reference `tab:maxdelays' on page 9 undefined on input line 387.
LaTeX Warning: There were undefined references. 
```